### PR TITLE
Fix missing import of IPython.display.display

### DIFF
--- a/notebooks/bar_data.ipynb
+++ b/notebooks/bar_data.ipynb
@@ -475,7 +475,7 @@
     }
    ],
    "source": [
-    "from IPython.display import clear_output\n",
+    "from IPython.display import display, clear_output\n",
     "import matplotlib.pyplot as plt\n",
     "\n",
     "prevBar = None\n",

--- a/notebooks/market_depth.ipynb
+++ b/notebooks/market_depth.ipynb
@@ -165,7 +165,7 @@
     }
    ],
    "source": [
-    "from IPython.display import clear_output\n",
+    "from IPython.display import display, clear_output\n",
     "import pandas as pd\n",
     "import time\n",
     "runUntil = time.time() + 15\n",

--- a/notebooks/tick_data.ipynb
+++ b/notebooks/tick_data.ipynb
@@ -253,7 +253,7 @@
     }
    ],
    "source": [
-    "from IPython.display import clear_output\n",
+    "from IPython.display import display, clear_output\n",
     "import pandas as pd\n",
     "import time\n",
     "runUntil = time.time() + 15\n",


### PR DESCRIPTION
These appear to have gotten lost from an earlier version.