### PR TITLE
Respect IB API limitation on 50 max rate of messages per second using ratelimit module

### DIFF
--- a/ib_insync/client.py
+++ b/ib_insync/client.py
@@ -5,6 +5,8 @@ import time
 import io
 from typing import List
 
+from ratelimit import rate_limited
+
 import ibapi
 from ibapi.client import EClient
 from ibapi.wrapper import EWrapper, iswrapper
@@ -450,6 +452,7 @@ class Connection:
     def isConnected(self):
         return self.socket is not None
 
+    @rate_limited(50)
     def sendMsg(self, msg):
         self.socket.transport.write(msg)
         self.numBytesSent += len(msg)

--- a/setup.py
+++ b/setup.py
@@ -34,5 +34,8 @@ setup(
         'Programming Language :: Python :: 3 :: Only',
     ],
     keywords='ibapi asyncio jupyter interactive brokers async',
-    packages=['ib_insync']
+    packages=['ib_insync'],
+    install_requires=[
+        'ratelimit',
+    ],
 )


### PR DESCRIPTION
Respect IB API limitation on 50 max rate of messages per second using ratelimit module.

When downloading option chains ib.qualifyContracts(*contracts) for a stock with a large number of option contracts - for example if one tries to call ib.qualifyContracts() on all FDX contracts from all expirations - TWS complains "Error 100: Max rate of messages per second has been exceeded." several times and then drops the connection. This patch resolves this issue by limiting max number of messages per second Connection::sendMsg() can send to 50 using ratelimit module.

See also: TWS Error Code 100 description: http://interactivebrokers.github.io/tws-api/message_codes.html#gsc.tab=0.

Here is the sample script to reproduce the issue:

```
from ib_insync import *

ib = IB()
ib.connect('127.0.0.1', 4001, clientId=1)

contract = Stock('FDX', exchange='SMART', currency='USD')
ib.qualifyContracts(contract)

chains = ib.reqSecDefOptParams(contract.symbol, '', contract.secType, contract.conId)
chain = next(c for c in chains if c.exchange == 'SMART')

strikes = [strike for strike in chain.strikes]
expirations = sorted(exp for exp in chain.expirations)
rights = ['P', 'C']

contracts = [Option(contract.symbol, expiration, strike, right, 'SMART') for right in rights for expiration in expirations for strike in strikes]

ib.qualifyContracts(*contracts)

ib.disconnect()

```
