### PR TITLE
ib.fills() returns incorrect results for partially filled orders for multi-leg option COMBO trades #36

### DIFF
--- a/ib_insync/wrapper.py
+++ b/ib_insync/wrapper.py
@@ -256,10 +256,7 @@ class Wrapper(EWrapper):
         # must handle both live fills and responses to reqExecutions
         key = (execution.clientId, execution.orderId)
         trade = self.trades.get(key)
-        if trade:
-            contract = trade.contract
-        else:
-            contract = Contract(**contract.__dict__)
+        contract = Contract(**contract.__dict__)
         execId = execution.execId
         execution = Execution(**execution.__dict__)
         fill = Fill(contract, execution, CommissionReport(), self.lastTime)


### PR DESCRIPTION
Proposed fix for the issue #36.

Not completely sure if this patch breaks something else, but I verified, it does solve the issue with my TradeLogIB script and partially filled multi-leg option orders. See issue description for more details.