### PR TITLE
Fix misnamed event

### DIFF
--- a/ib_insync/ib.py
+++ b/ib_insync/ib.py
@@ -658,7 +658,7 @@ class IB:
                 self._logger.info(f'cancelOrder: {trade}')
                 trade.cancelEvent.emit(trade)
                 trade.statusEvent.emit(trade)
-                self.orderCancelEvent.emit(trade)
+                self.cancelOrderEvent.emit(trade)
                 self.orderStatusEvent.emit(trade)
         else:
             self._logger.error(f'cancelOrder: Unknown orderId {order.orderId}')


### PR DESCRIPTION
Fixes: 
```python
--> 661                 self.orderCancelEvent.emit(trade)
    662                 self.orderStatusEvent.emit(trade)
    663         else:

AttributeError: 'IB' object has no attribute 'orderCancelEvent'
```

I went with this naming because it's what's already in the doc and in the events list.