### PR TITLE
Apply wait_for to event_loop to raise timeout exeption.

### DIFF
--- a/ib_insync/util.py
+++ b/ib_insync/util.py
@@ -359,7 +359,7 @@ def syncAwait(future):
         isQuamash = False
 
     if not loop.is_running():
-        result = loop.run_until_complete(future)
+        result = loop.run_until_complete(asyncio.wait_for(future, 30))
     elif isQuamash:
         result = _syncAwaitQt(future)
     else:


### PR DESCRIPTION
While getting Historical Data with `reqHistoricalData` method, networking deadlock can be happened after the network socket is accidentally disconnected. I'd like to suggest to use `wait_for` to avoid this. And the default timeout setting must be needed.

As I'm not very familiar with async, please give me an advise to solve this problem.