### PR TITLE
Handle tickTypes related to auctions

### DIFF
--- a/ib_insync/ib.py
+++ b/ib_insync/ib.py
@@ -1165,6 +1165,7 @@ class IB:
                        ``high26week``, ``low52week``, ``high52week``,
                        ``avVolume``
                 221    ``markPrice``
+                225    ``auctionVolume``, ``auctionPrice``, ``auctionImbalance``
                 233    ``last``, ``lastSize``, ``rtVolume``, ``vwap``
                        (Time & Sales)
                 236    ``shortableShares``

--- a/ib_insync/ticker.py
+++ b/ib_insync/ticker.py
@@ -90,7 +90,10 @@ class Ticker(Object):
         bidGreeks=None,
         askGreeks=None,
         lastGreeks=None,
-        modelGreeks=None
+        modelGreeks=None,
+        auctionVolume=nan,
+        auctionPrice=nan,
+        auctionImbalance=nan
     )
     __slots__ = tuple(defaults.keys()) + events + ('__dict__',)
 

--- a/ib_insync/wrapper.py
+++ b/ib_insync/wrapper.py
@@ -613,6 +613,12 @@ class Wrapper:
             ticker.callVolume = size
         elif tickType == 30:
             ticker.putVolume = size
+        elif tickType == 34:
+            ticker.auctionVolume = size
+        elif tickType == 35:
+            ticker.auctionPrice = size
+        elif tickType == 36:
+            ticker.auctionImbalance = size
         elif tickType == 86:
             ticker.futuresOpenInterest = size
         elif tickType == 87:


### PR DESCRIPTION
* Handle tickType 34, 35, 36 in wrapper
* Assign default ``nan`` for  ``auctionVolume``, ``auctionPrice``, ``auctionImbalance`` in  ``ticker`` class.
* Document ``auctionVolume``, ``auctionPrice``, ``auctionImbalance`` as return of genericTick 225 (https://interactivebrokers.github.io/tws-api/tick_types.html)
