### PR TITLE
Util schedule: return Events Handle.

### DIFF
--- a/ib_insync/util.py
+++ b/ib_insync/util.py
@@ -272,6 +272,7 @@ def schedule(
     """
     Schedule the callback to be run at the given time with
     the given arguments.
+    This will return the Event Handle.
 
     Args:
         time: Time to run callback. If given as :py:class:`datetime.time`
@@ -283,7 +284,7 @@ def schedule(
     now = datetime.datetime.now(dt.tzinfo)
     delay = (dt - now).total_seconds()
     loop = asyncio.get_event_loop()
-    loop.call_later(delay, callback, *args)
+    return loop.call_later(delay, callback, *args)
 
 
 def sleep(secs: float = 0.02) -> bool:


### PR DESCRIPTION
Scheduling callbacks using util.schedule should return the Event Handle (that is always returned from asyncio when scheduling).

This can be used to cancel scheduled callbacks.
For example, when the watchdog emit the stopped event and there are scheduled jobs that requires connected ib.