### PR TITLE
Switch to PEP440-compatible generated versions

### DIFF
--- a/ib_insync/__init__.py
+++ b/ib_insync/__init__.py
@@ -6,7 +6,7 @@ if sys.version_info < (3, 6, 0):
 
 from eventkit import Event
 
-from .version import __version__, __version_info__
+from .version import __version__
 from .objects import (
     Object, ContractDetails, ContractDescription,
     ComboLeg, DeltaNeutralContract, OrderComboLeg, OrderState,

--- a/ib_insync/version.py
+++ b/ib_insync/version.py
@@ -1,2 +1,1 @@
-__version_info__ = (0, 9, 56)
-__version__ = '.'.join(str(v) for v in __version_info__)
+__version__ = 0.9.56.dev20+g15fb8d9

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
 import os
 import sys
 import codecs
+import subprocess
 from setuptools import setup
 
 if sys.version_info < (3, 6, 0):
@@ -8,8 +9,19 @@ if sys.version_info < (3, 6, 0):
 
 here = os.path.abspath(os.path.dirname(__file__))
 
-__version__ = None
-exec(open(os.path.join(here, 'ib_insync', 'version.py')).read())
+def git_pep440_version(path):
+    def git_command(args):
+        prefix = ['git', '-C', path]
+        return subprocess.check_output(prefix + args).decode().strip()
+    version_full = git_command(['describe', '--tags', '--dirty=.dirty'])
+    version_tag = git_command(['describe', '--tags', '--abbrev=0'])
+    version_tail = version_full[len(version_tag):]
+    return version_tag + version_tail.replace('-', '.dev', 1).replace('-', '+', 1)
+
+__version__ = git_pep440_version(here)
+
+with open(os.path.join(here, 'ib_insync', 'version.py'), "w") as vf:
+    print(f"__version__ = {__version__}", file=vf)
 
 with codecs.open(os.path.join(here, 'README.rst'), encoding='utf-8') as f:
     long_description = f.read()


### PR DESCRIPTION
This depends on using annotated tags to mark releases.

To start it off, create a tag for the 0.9.56 release with:
  git tag -a -m 'version 0.9.56 release' 0.9.56 8d0dcf1
before merging this changeset.

After that, create an annotated tag to mark and describe the release.