### PR TITLE
Treat error 492 ('You must subscribe for additional permissions to ob…

### DIFF
--- a/ib_insync/wrapper.py
+++ b/ib_insync/wrapper.py
@@ -942,7 +942,7 @@ class Wrapper:
 
     def error(self, reqId, errorCode, errorString):
         # https://interactivebrokers.github.io/tws-api/message_codes.html
-        warningCodes = {165, 202, 399, 434, 10167}
+        warningCodes = {165, 202, 399, 434, 492, 10167}
         isWarning = errorCode in warningCodes or 2100 <= errorCode < 2200
         msg = (
             f'{"Warning" if isWarning else "Error"} '


### PR DESCRIPTION
…tain precise results for scanner') as warning

When you don't have market data subscriptions and do a blocking `reqScannerData()`, you'll get this error message. But IB will also send results.
However, by then the `future` is already cancelled by `wrapper.py`.
So, this error (492) should be a warning, imho.