### PR TITLE
watchdog: restart on error 100

### DIFF
--- a/ib_insync/ibcontroller.py
+++ b/ib_insync/ibcontroller.py
@@ -327,7 +327,7 @@ class Watchdog(Object):
     a certain amount of time (the ``appTimeout`` parameter). This triggers
     a historical request to be placed just to see if the app is still alive
     and well. If yes, then continue, if no then restart the whole app
-    and reconnect. Restarting will also occur directly on error 1100.
+    and reconnect. Restarting will also occur directly on errors 1100 and 100.
 
     Example usage:
 
@@ -405,8 +405,8 @@ class Watchdog(Object):
                 waiter.set_result(None)
 
         def onError(reqId, errorCode, errorString, contract):
-            if errorCode == 1100 and not waiter.done():
-                waiter.set_exception(Warning('Error 1100'))
+            if errorCode in [1100, 100] and not waiter.done():
+                waiter.set_exception(Warning(f'Error {errorCode}'))
 
         def onDisconnected():
             if not waiter.done():


### PR DESCRIPTION
According to IB, on error 100 
> The TWS will likely disconnect the client application after this message.

The watchdog can't detect the client disconnection in this scenario,
As it won't be followed with error 1100, and the disconnect event wont fire.

Links:
[IB error codes](https://interactivebrokers.github.io/tws-api/message_codes.html)
[Example case](https://groups.io/g/insync/topic/max_rate_of_messages/6390099?p=,,,20,0,0,0::recentpostdate%2Fsticky,,,20,2,0,6390099)