### PR TITLE
Pass account name to ib.connect()

### DIFF
--- a/ib_insync/ib.py
+++ b/ib_insync/ib.py
@@ -233,7 +233,7 @@ class IB:
         return f'<{self.__class__.__qualname__} {conn}>'
 
     def connect(
-            self, host: str = '127.0.0.1', port: int = 7497,
+            self, host: str = '127.0.0.1', port: int = 7497, account: str = '',
             clientId: int = 1, timeout: float = 2, readonly: bool = False):
         """
         Connect to a running TWS or IB gateway application.
@@ -1614,7 +1614,7 @@ class IB:
 
     async def connectAsync(
             self, host='127.0.0.1', port=7497, clientId=1,
-            timeout=2, readonly=False):
+            timeout=2, readonly=False, account=''):
 
         async def connect():
             self.wrapper.clientId = clientId
@@ -1623,7 +1623,7 @@ class IB:
                 await self.reqCompletedOrdersAsync(False)
             accounts = self.client.getAccounts()
             await asyncio.gather(
-                self.reqAccountUpdatesAsync(accounts[0]),
+                self.reqAccountUpdatesAsync(accounts[0] if account=='' else account),
                 *(self.reqAccountUpdatesMultiAsync(a) for a in accounts),
                 self.reqPositionsAsync(),
                 self.reqExecutionsAsync())


### PR DESCRIPTION
Usage: ib.connect('127.0.0.1', 1234, clientId=1, timeout=360, account='U1234567')
This is necessary when working with >1 accounts.
For example, let's say I have both a regular (U0000001) and an IRA (U0000002) accounts with IB. Let's say I call ib.connect(...) to trade using U0000002 in my IRA. When called, ib.connect() configures portfolio updates for the default account U0000001. So next, I have to call ib.reqAccountUpdates(account='U0000002') to get portfolio updates for U0000002.
Next, say I want to download history while the trading code trades. I launch another Python code to access API for account U0000002. That code calls ib.connect() and now ib.connect() *fails* because the trading code is getting portfolio updates (or feed) for account U0000002, but ib.connect() in my history download code by default connects to U0000001. IB does not allow using portfolio update (or feed) with different accounts simultaneously.
A fix for this is to pass account name to ib.connect(), so ib.connect() connects to the correct account.