### PR TITLE
Update util.py

### DIFF
--- a/ib_insync/util.py
+++ b/ib_insync/util.py
@@ -511,7 +511,7 @@ def formatIBDatetime(dt: Union[date, datetime, str, None]) -> str:
     return s
 
 
-def parseIBDatetime(s: str):
+def parseIBDatetime(s: str) -> datetime:
     """Parse string in IB date or datetime format to datetime."""
     if len(s) == 8:
         # YYYYmmdd

--- a/ib_insync/util.py
+++ b/ib_insync/util.py
@@ -511,7 +511,7 @@ def formatIBDatetime(dt: Union[date, datetime, str, None]) -> str:
     return s
 
 
-def parseIBDatetime(s: str) -> datetime.datetime:
+def parseIBDatetime(s: str) -> Union[datetime.date, datetime.datetime]:
     """Parse string in IB date or datetime format to datetime."""
     if len(s) == 8:
         # YYYYmmdd

--- a/ib_insync/util.py
+++ b/ib_insync/util.py
@@ -511,7 +511,7 @@ def formatIBDatetime(dt: Union[date, datetime, str, None]) -> str:
     return s
 
 
-def parseIBDatetime(s: str) -> datetime:
+def parseIBDatetime(s: str) -> datetime.datetime:
     """Parse string in IB date or datetime format to datetime."""
     if len(s) == 8:
         # YYYYmmdd


### PR DESCRIPTION
typing added for `parseIBDatetime`
return type was missing