### PR TITLE
Add a coro to run watchdog forever.

### DIFF
--- a/ib_insync/ibcontroller.py
+++ b/ib_insync/ibcontroller.py
@@ -393,6 +393,10 @@ class Watchdog:
         self.startingEvent.emit(self)
         self._runner = asyncio.ensure_future(self.runAsync())
 
+    async def runForeverAsync(self):
+        start()
+        await self._runner
+
     def stop(self):
         self._logger.info('Stopping')
         self.stoppingEvent.emit(self)


### PR DESCRIPTION
The watchdog can be awaited on and be compatible with other
asyncio coros.