### PR TITLE
Changed orderId so it will incremented automatically by the client

### DIFF
--- a/ib_insync/order.py
+++ b/ib_insync/order.py
@@ -24,7 +24,7 @@ class Order:
     https://interactivebrokers.github.io/tws-api/available_orders.html
     """
 
-    orderId: int = 0
+    orderId: int = None
     clientId: int = 0
     permId: int = 0
     action: str = ''


### PR DESCRIPTION
Not sure if it is appreciated, but I ran into this and it seems like it might be unintended that the `orderId` does not auto-increment by the client.