### PR TITLE
Don't discard RT Volume time stamps

### DIFF
--- a/ib_insync/ticker.py
+++ b/ib_insync/ticker.py
@@ -46,7 +46,8 @@ class Ticker:
     contract: Optional[Contract] = None
     time: Optional[datetime] = None
     marketDataType: int = 1
-    last_fill_time: Optional[float] = None
+    # last clearing price time at exchange in seconds
+    lastFillTime: Optional[float] = None
     bid: float = nan
     bidSize: float = nan
     ask: float = nan

--- a/ib_insync/ticker.py
+++ b/ib_insync/ticker.py
@@ -46,6 +46,7 @@ class Ticker:
     contract: Optional[Contract] = None
     time: Optional[datetime] = None
     marketDataType: int = 1
+    last_fill_time: Optional[float] = None
     bid: float = nan
     bidSize: float = nan
     ask: float = nan

--- a/ib_insync/ticker.py
+++ b/ib_insync/ticker.py
@@ -46,8 +46,6 @@ class Ticker:
     contract: Optional[Contract] = None
     time: Optional[datetime] = None
     marketDataType: int = 1
-    # last clearing price time at exchange in seconds
-    lastFillTime: Optional[float] = None
     bid: float = nan
     bidSize: float = nan
     ask: float = nan
@@ -77,9 +75,14 @@ class Ticker:
     lastYield: float = nan
     markPrice: float = nan
     halted: float = nan
+
+    # fields from IB "RT Volume" feed:
+    # https://interactivebrokers.github.io/tws-api/tick_types.html#rt_volume
+    rtTime: Optional[int] = None
     rtHistVolatility: float = nan
     rtVolume: float = nan
     rtTradeVolume: float = nan
+
     avVolume: float = nan
     tradeCount: float = nan
     tradeRate: float = nan

--- a/ib_insync/wrapper.py
+++ b/ib_insync/wrapper.py
@@ -759,7 +759,7 @@ class Wrapper:
                 price_str, size, time_ms, volume, vwap, _ = value.split(';')
 
                 # always track the exchange time in seconds
-                ticker.last_fill_time = float(int(time_ms) / 1000.)
+                ticker.lastFillTime = float(int(time_ms) / 1000.)
 
                 if volume:
                     if tickType == 48:
@@ -1046,7 +1046,7 @@ class Wrapper:
     def tcpDataArrived(self):
         self.lastTime = datetime.now(timezone.utc)
         for ticker in self.pendingTickers:
-            ticker.last_fill_time = None
+            ticker.lastFillTime = None
             ticker.ticks = []
             ticker.tickByTicks = []
             ticker.domTicks = []

--- a/ib_insync/wrapper.py
+++ b/ib_insync/wrapper.py
@@ -759,7 +759,7 @@ class Wrapper:
                 price_str, size, time_ms, volume, vwap, _ = value.split(';')
 
                 # always track the exchange time in seconds
-                ticker.lastFillTime = float(int(time_ms) / 1000.)
+                ticker.rtTime = int(time_ms)
 
                 if volume:
                     if tickType == 48:
@@ -1046,7 +1046,7 @@ class Wrapper:
     def tcpDataArrived(self):
         self.lastTime = datetime.now(timezone.utc)
         for ticker in self.pendingTickers:
-            ticker.lastFillTime = None
+            ticker.rtTime = None
             ticker.ticks = []
             ticker.tickByTicks = []
             ticker.domTicks = []


### PR DESCRIPTION
Relates to #274.

Parse the millisecond time stamps received from `genericTick` `77` and `48` convert it to `float` seconds and save to a new attribute
`Ticker.last_fill_time`.

This field is absolutely essential for anykind of accurate charting on small time frames.

I'm not married to any particular name for this attribute, some alternatives:
- `last_clearing_time`
- `last_volume_time`
- `last_trade_time`

Note, I also dropped a duplicate code block for tick `77` which wasn't being executed ever due to the `elif`.

I would like to also add some basic tests for this and an example in the docs if that's ok @erdewit.

I was thinking that the example you provided in #262 using `asyncio.run()` would be a good start.

For testing I was thinking of starting a suite that can be run by anyone with a data subscription *locally*.
We could do something simple like add some more examples and [run them from `pytest`](https://github.com/goodboy/tractor/blob/master/tests/test_docs_examples.py) as well as include them using sphinx's [..literalinclude](https://www.sphinx-doc.org/en/master/usage/restructuredtext/directives.html#directive-literalinclude) directive directly from the `examples/` directory into the documentation.
 
What do you think about working towards using a docker container (choose one from #261 ?) in CI to run tests on commits down the road?

TODO:
- [x] change name to `rtTime` as per @erdewit request and naming consistency
- [ ] doc string documentation at `IB.reqMktData` for ID=233
- [ ] make it a `datetime`. I'm personally really opposed to this.