### PR TITLE
Add ib_insync.wrapper.RequestError and optionally raise it

### DIFF
--- a/ib_insync/ib.py
+++ b/ib_insync/ib.py
@@ -189,9 +189,17 @@ class IB:
     RequestTimeout: float = 0
     MaxSyncedSubAccounts: int = 50
 
-    def __init__(self):
+    def __init__(self, quash_errors=True):
+        """
+        :param bool quash_errors:
+            If :data:`True`, when an API request fails, its future will be set
+            to some default value, usually an empty list.
+
+            If :data:`False`, the future is caused to fail with
+            :class:`~ib_insync.wrapper.RequestError` when an API request fails.
+        """
         self._createEvents()
-        self.wrapper = Wrapper(self)
+        self.wrapper = Wrapper(self, quash_errors)
         self.client = Client(self.wrapper)
         self.errorEvent += self._onError
         self.client.apiEnd += self.disconnectedEvent


### PR DESCRIPTION
When a request fails, say, `orderWhatIf()` due to running in read-only mode, presently this is not propagated back to the caller. Instead she receives an empty list (which isn't even the correct type), and the true error is buried in the logs.

No doubt users (just like me) have code that relies on the old behaviour, so it wouldn't be a good idea to change without a version bump, so instead expose a new `IB(quash_errors=False)` constructor parameter that instead causes an exception to be propagated to pending futures where possible.

I did not regenerate the docs in this PR because I couldn't get the Sphinx config to match whatever setup was used to generate the checked in docs.