### PR TITLE
Update quantity/price in wrapper.openOrder()

### DIFF
--- a/ib_insync/wrapper.py
+++ b/ib_insync/wrapper.py
@@ -343,6 +343,9 @@ class Wrapper:
             trade = self.trades.get(key)
             if trade:
                 trade.order.permId = order.permId
+                trade.order.totalQuantity = order.totalQuantity
+                trade.order.lmtPrice = order.lmtPrice
+                trade.order.auxPrice = order.auxPrice
             else:
                 # ignore '?' values in the order
                 order = Order(**{


### PR DESCRIPTION
In a prior commit it seems that similar functionality was removed (https://github.com/erdewit/ib_insync/commit/e23e6ff52c12b54b795767cb1d5e9705a9b797d4). I am not sure of why - therefore I propose this change.

# Use case:
1) Create order of e.g. quantity 1000
2) Resize it to quantity 1100
3) List all open orders using `ib.openTrades()` - there it will still have totalQuantity 1000. But orderStatus.remaining will be 1100 and it will be 1100 in IB TWS. 

Similarly for price changes.