### PR TITLE
remove the index of DataFrame before write to CSV

### DIFF
--- a/docs/recipes.rst
+++ b/docs/recipes.rst
@@ -45,8 +45,7 @@ and further back in time until there is no more data returned.
     # save to CSV file
     allBars = [b for bars in reversed(barsList) for b in bars]
     df = util.df(allBars)
-    df.reset_index(drop=True, inplace=True)
-    df.to_csv(contract.symbol + '.csv')
+    df.to_csv(contract.symbol + '.csv', index=False)
 
 Scanner data (blocking)
 ^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/recipes.rst
+++ b/docs/recipes.rst
@@ -45,6 +45,7 @@ and further back in time until there is no more data returned.
     # save to CSV file
     allBars = [b for bars in reversed(barsList) for b in bars]
     df = util.df(allBars)
+    df.reset_index(drop=True, inplace=True)
     df.to_csv(contract.symbol + '.csv')
 
 Scanner data (blocking)


### PR DESCRIPTION
The DataFrame has a index by default, and when `.to_csv` is called, the first column in the csv file is the index, and there is no header for that column. It makes the csv not able to be parsed by other program. Example data is like
```
,date,open,high,low,close,volume,average,barCount
0,2020-10-16 10:40:00,3476.25,3476.25,3476.25,3476.25,1,3476.25,1
1,2020-10-16 10:41:00,3476.75,3476.75,3476.75,3476.75,1,3476.75,1
2,2020-10-16 10:42:00,3476.75,3476.75,3476.75,3476.75,0,3476.75,0
3,2020-10-16 10:43:00,3475.75,3475.75,3475.75,3475.75,5,3475.75,3
4,2020-10-16 10:44:00,3475.75,3475.75,3475.75,3475.75,0,3475.75,0
5,2020-10-16 10:45:00,3475.75,3475.75,3475.75,3475.75,0,3475.75,0
6,2020-10-16 10:46:00,3475.75,3475.75,3475.75,3475.75,0,3475.75,0
7,2020-10-16 10:47:00,3475.75,3475.75,3475.75,3475.75,0,3475.75,0
8,2020-10-16 10:48:00,3475.75,3475.75,3475.75,3475.75,0,3475.75,0
```