### PR TITLE
Fixed logToConsole chaning root logger configuration, now log level c…

### DIFF
--- a/ib_insync/util.py
+++ b/ib_insync/util.py
@@ -207,9 +207,19 @@ def allowCtrlC():
     signal.signal(signal.SIGINT, signal.SIG_DFL)
 
 
-def logToFile(path, level=logging.INFO):
-    """Create a log handler that logs to the given file."""
-    logger = logging.getLogger()
+def logToFile(path, level=logging.INFO, only_for_package=False):
+    """
+    Create a log handler that logs to the given file.
+
+    Passing only_for_package=True will change the formatting and output only for ib_insync
+    package-level loggers and any others that derive from it
+    """
+
+    if only_for_package:
+        logger = logging.getLogger(__package__)
+    else:
+        logger = logging.getLogger()
+
     logger.setLevel(level)
     formatter = logging.Formatter(
         '%(asctime)s %(name)s %(levelname)s %(message)s')
@@ -218,9 +228,18 @@ def logToFile(path, level=logging.INFO):
     logger.addHandler(handler)
 
 
-def logToConsole(level=logging.INFO):
-    """Create a log handler that logs to the console."""
-    logger = logging.getLogger()
+def logToConsole(level=logging.INFO, only_for_package=False):
+    """
+    Create a log handler that logs to the console.
+
+    Passing only_for_package=True will change the formatting and output only for ib_insync
+    package level loggers and any others that derive from it
+    """
+    if only_for_package:
+        logger = logging.getLogger(__package__)
+    else:
+        logger = logging.getLogger()
+
     logger.setLevel(level)
     formatter = logging.Formatter(
         '%(asctime)s %(name)s %(levelname)s %(message)s')


### PR DESCRIPTION
In the context of this file, the last `logging.debug` message will not displayed, because `logToConsole` changes the root logger configuration. I spent an hour debugging bizare logger errors out of my multi-layered system 

```
import ib_insync
import logging

logging.basicConfig(level=logging.DEBUG)

ib_insync.util.logToConsole(level=logging.ERROR)

ib = ib_insync.IB()
ib.connect('127.0.0.1', port=7497, clientId=1, readonly=True)
logging.debug('I will not be displayed')
```

So I added an optional boolean `only_for_package` to change only `ib_insync.*` loggers 

```
import ib_insync
import logging

logging.basicConfig(level=logging.DEBUG)

ib_insync.util.logToConsole(level=logging.ERROR, only_for_package=True)

ib = ib_insync.IB()
ib.connect('127.0.0.1', port=7497, clientId=1, readonly=True)
logging.debug('I will be displayed')
```

As a side note, there seems to be some incompatibility of `logToConsole` (aka `logging`) and `asyncio`. https://stackoverflow.com/questions/64679139/nameerror-name-open-is-not-defined-when-trying-to-log-to-files