### PR TITLE
Add summary request for future daily day trade limits

### DIFF
--- a/ib_insync/ib.py
+++ b/ib_insync/ib.py
@@ -1768,7 +1768,9 @@ class IB:
             'FullAvailableFunds,FullExcessLiquidity,LookAheadNextChange,'
             'LookAheadInitMarginReq,LookAheadMaintMarginReq,'
             'LookAheadAvailableFunds,LookAheadExcessLiquidity,'
-            'HighestSeverity,DayTradesRemaining,Leverage,$LEDGER:ALL')
+            'HighestSeverity,DayTradesRemaining,DayTradesRemainingT+1,'
+            'DayTradesRemainingT+2,DayTradesRemainingT+3,DayTradesRemainingT+4,'
+            'Leverage,$LEDGER:ALL')
         self.client.reqAccountSummary(reqId, 'All', tags)
         return future
 


### PR DESCRIPTION
IBKR exposes the "daytrades remaining" counter as up to 5 values: one for
the current day, then more individual counts for 4 future days when the
limits will increase again.