### PR TITLE
Update `wrapper.trades` on order modifications using placeOrder

### DIFF
--- a/ib_insync/ib.py
+++ b/ib_insync/ib.py
@@ -641,7 +641,7 @@ class IB:
         if trade:
             # this is a modification of an existing order
             assert trade.orderStatus.status not in OrderStatus.DoneStates
-            
+
             # update modified order, instead of wait for openOrder-callback
             trade.order.totalQuantity = order.totalQuantity
             trade.order.lmtPrice = order.lmtPrice

--- a/ib_insync/ib.py
+++ b/ib_insync/ib.py
@@ -642,7 +642,7 @@ class IB:
             # this is a modification of an existing order
             assert trade.orderStatus.status not in OrderStatus.DoneStates
             
-            # instant update of modified order, instead of waiting for openOrder-callback
+            # update modified order, instead of wait for openOrder-callback
             trade.order.totalQuantity = order.totalQuantity
             trade.order.lmtPrice = order.lmtPrice
             trade.order.auxPrice = order.auxPrice

--- a/ib_insync/ib.py
+++ b/ib_insync/ib.py
@@ -641,6 +641,13 @@ class IB:
         if trade:
             # this is a modification of an existing order
             assert trade.orderStatus.status not in OrderStatus.DoneStates
+            
+            # instant update of modified order, instead of waiting for openOrder-callback
+            trade.order.totalQuantity = order.totalQuantity
+            trade.order.lmtPrice = order.lmtPrice
+            trade.order.auxPrice = order.auxPrice
+            trade.order.orderType = order.orderType
+
             logEntry = TradeLogEntry(now, trade.orderStatus.status, 'Modify')
             trade.log.append(logEntry)
             self._logger.info(f'placeOrder: Modify order {trade}')


### PR DESCRIPTION
Currently, ib_insync updates the local state in `wrapper.trades` as part of the openOrder callback. The relevant source code for this is referred to in  https://github.com/erdewit/ib_insync/pull/317. Through actual trading I have observed that it can a long time (in the range 0-60s) to get such a callback for an order modification.

Therefore I propose that it should optimistically update the local order state already in the `placeOrder` function. 
A similar optimistic update is already done in the case of new orders, namely by add to the trades-dictionary:
https://github.com/erdewit/ib_insync/blob/11cfe104efb96818f12779dc2741388a235d8092/ib_insync/ib.py#L658

In this way, one can rely on `wrapper.trades` info for deciding on whether to issue a order modification or not, instead issuing several equivalent updates.
