### PR TITLE
Return possible contract results; makes type annot correct

### DIFF
--- a/ib_insync/ib.py
+++ b/ib_insync/ib.py
@@ -1715,6 +1715,8 @@ class IB:
                 self._logger.error(
                     f'Ambiguous contract: {contract}, '
                     f'possibles are {possibles}')
+                # return all possible contracts that match
+                result.extend(possibles)
             else:
                 c = detailsList[0].contract
                 expiry = c.lastTradeDateOrContractMonth


### PR DESCRIPTION
Makes it possible to retrieve all contracts for a given (derivative) name.
Also makes the return value type annotation correct (because otherwise it should be `Optional[List[Contract]]` 😉)

This small change is particularly handy for implementing symbol search where you only want to force providing the generic instrument name (eg. `MNQ.GLOBEX`).

Let me know if there's any tests I need to write to get this in 🏄🏼 