### PR TITLE
watchdog.start() return runAsync future

### DIFF
--- a/ib_insync/ibcontroller.py
+++ b/ib_insync/ibcontroller.py
@@ -394,6 +394,7 @@ class Watchdog:
         self._logger.info('Starting')
         self.startingEvent.emit(self)
         self._runner = asyncio.ensure_future(self.runAsync())
+        return self._runner
 
     def stop(self):
         self._logger.info('Stopping')


### PR DESCRIPTION
The purpose of this change is to be able to await the runAsync future completion external to watchdog.
Without awaiting for the runAsync task to complete the "finally" part of the function is not executed following `watchdog.stop()`, `onDisconnected`, and `waiter.set_exception(Warning('Disconnected'))` resulting in IB_Gateway instance running without proper termination.

An alternative to this change would be to await for the runAsync task to complete internally to the watchdog class - but that would involve rework of the while loop dependency on the `self._runner = None` and/or keeping the runAsync task reference in a separate variable that would be awaited in `watchdog.stop()`.