### PR TITLE
missing '*fields' on bondContractDetails

### DIFF
--- a/ib_insync/decoder.py
+++ b/ib_insync/decoder.py
@@ -384,7 +384,7 @@ class Decoder:
                 tag, value, *fields = fields
                 cd.secIdList += [TagValue(tag, value)]
 
-        cd.aggGroup, cd.marketRuleIds = fields
+        cd.aggGroup, cd.marketRuleIds, *fields = fields
         if self.serverVersion >= 164:
             (
                 cd.minSize,


### PR DESCRIPTION
Missing '*fields' to collect additional fields on bondContractDetails.
Without the proposed patch bondContractDetails() fails with current server versions
