### PR TITLE
Fix:  Avoid ticker leakage in reqTickers

### DIFF
--- a/ib_insync/ib.py
+++ b/ib_insync/ib.py
@@ -1762,7 +1762,8 @@ class IB:
             self.client.reqMktData(
                 reqId, contract, '', True, regulatorySnapshot, [])
         await asyncio.gather(*futures)
-        for ticker in tickers:
+        for ticker, reqId in zip(tickers, reqIds):
+            self.client.cancelMktData(reqId)
             self.wrapper.endTicker(ticker, 'snapshot')
         return tickers
 


### PR DESCRIPTION
Cancel ticker subscription, as 'snapshot' tickers still seem to accumulate on TWS side after being discarded on ib_insync side. As the result it takes progressively more time to receive new tickers. This become noticeable when retrieving option tables for several maturities.