### PR TITLE
Fixes ValueError

### DIFF
--- a/ib_insync/contract.py
+++ b/ib_insync/contract.py
@@ -525,7 +525,7 @@ class ContractDetails:
         tz = util.ZoneInfo(self.timeZoneId)
         sessions = []
         for sess in s.split(';'):
-            if 'CLOSED' in sess:
+            if sess in ('CLOSED', ''):
                 continue
             sessions.append(TradingSession(*[
                 dt.datetime.strptime(t, '%Y%m%d:%H%M').replace(tzinfo=tz)


### PR DESCRIPTION
Ignore when `sess` is an empty string. from days where there is no trading session or liquid session.

```python
[in]:
from ib_insync import IB, Forex, util
import datetime
util.patchAsyncio()
ib = IB()
ib.connect(clientId=69)
d = ib.reqContractDetails(Forex('EURUSD'))
print(datetime.datetime.now())
print(d[0].tradingHours)
print(d[0].tradingSessions())

[out]:
2022-12-18 13:42:47.514007
;20221218:1715-20221219:1700;20221219:1715-20221220:1700;20221220:1715-20221221:1700;20221221:1715-20221222:1700;20221222:1715-20221223:1700
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
Cell In[1], line 9
      7 print(datetime.datetime.now())
      8 print(d[0].tradingHours)
----> 9 print(d[0].tradingSessions())

File ~/Library/Caches/pypoetry/virtualenvs/ariobot-RQMH0swU-py3.10/lib/python3.10/site-packages/ib_insync/contract.py:519, in ContractDetails.tradingSessions(self)
    518 def tradingSessions(self) -> List[TradingSession]:
--> 519     return self._parseSessions(self.tradingHours)

File ~/Library/Caches/pypoetry/virtualenvs/ariobot-RQMH0swU-py3.10/lib/python3.10/site-packages/ib_insync/contract.py:530, in ContractDetails._parseSessions(self, s)
    528     if 'CLOSED' in sess:
    529         continue
--> 530     sessions.append(TradingSession(*[
    531         dt.datetime.strptime(t, '%Y%m%d:%H%M').replace(tzinfo=tz)
    532         for t in sess.split('-')]))
    533 return sessions

File ~/Library/Caches/pypoetry/virtualenvs/ariobot-RQMH0swU-py3.10/lib/python3.10/site-packages/ib_insync/contract.py:531, in <listcomp>(.0)
    528     if 'CLOSED' in sess:
    529         continue
    530     sessions.append(TradingSession(*[
--> 531         dt.datetime.strptime(t, '%Y%m%d:%H%M').replace(tzinfo=tz)
    532         for t in sess.split('-')]))
    533 return sessions

File ~/.pyenv/versions/3.10.2/lib/python3.10/_strptime.py:568, in _strptime_datetime(cls, data_string, format)
    565 def _strptime_datetime(cls, data_string, format="%a %b %d %H:%M:%S %Y"):
    566     """Return a class cls instance based on the input string and the
    567     format string."""
--> 568     tt, fraction, gmtoff_fraction = _strptime(data_string, format)
    569     tzname, gmtoff = tt[-2:]
    570     args = tt[:6] + (fraction,)

File ~/.pyenv/versions/3.10.2/lib/python3.10/_strptime.py:349, in _strptime(data_string, format)
    347 found = format_regex.match(data_string)
    348 if not found:
--> 349     raise ValueError("time data %r does not match format %r" %
    350                      (data_string, format))
    351 if len(data_string) != found.end():
    352     raise ValueError("unconverted data remains: %s" %
    353                       data_string[found.end():])

ValueError: time data '' does not match format '%Y%m%d:%H%M'
```