### PR TITLE
Fix option date with timezone parsing 

### DIFF
--- a/ib_insync/util.py
+++ b/ib_insync/util.py
@@ -11,6 +11,10 @@ from dataclasses import fields, is_dataclass
 from typing import (
     AsyncIterator, Awaitable, Callable, Iterator, List, Optional, Union)
 
+from pytz import timezone
+from dateutil.parser import parse
+
+
 import eventkit as ev
 
 try:
@@ -541,6 +545,9 @@ def parseIBDatetime(s: str) -> Union[dt.date, dt.datetime]:
         s0, s1, s2 = s.split(' ', 2)
         t = dt.datetime.strptime(s0 + s1, '%Y%m%d%H:%M:%S')
         t = t.replace(tzinfo=ZoneInfo(s2))
+    elif s.includes('/'):
+        s0, s1 = s.split(' ')
+        t = parse('12:07:17', tzinfos={s1: timezone(s1)})
     else:
         # YYYYmmdd  HH:MM:SS
         # or

--- a/ib_insync/util.py
+++ b/ib_insync/util.py
@@ -547,7 +547,7 @@ def parseIBDatetime(s: str) -> Union[dt.date, dt.datetime]:
         t = t.replace(tzinfo=ZoneInfo(s2))
     elif '/' in s:
         s0, s1 = s.split(' ')
-        t = parse('12:07:17', tzinfos={s1: timezone(s1)})
+        t = parse(s0, tzinfos={s1: timezone(s1)})
     else:
         # YYYYmmdd  HH:MM:SS
         # or

--- a/ib_insync/util.py
+++ b/ib_insync/util.py
@@ -545,7 +545,7 @@ def parseIBDatetime(s: str) -> Union[dt.date, dt.datetime]:
         s0, s1, s2 = s.split(' ', 2)
         t = dt.datetime.strptime(s0 + s1, '%Y%m%d%H:%M:%S')
         t = t.replace(tzinfo=ZoneInfo(s2))
-    elif s.includes('/'):
+    elif '/' in s:
         s0, s1 = s.split(' ')
         t = parse('12:07:17', tzinfos={s1: timezone(s1)})
     else:

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,5 @@ eventkit
 nest_asyncio
 dataclasses;python_version<"3.7"
 backports.zoneinfo;python_version<"3.9"
+pytz
+python-dateutil


### PR DESCRIPTION
Ran into an issue where IB was returning a datetime as '12:07:17 US/Central' for an options contract.

Fixed it by modifying `parseIBDatetime` to parse it using `dateutil` and `pytz`.