### PR TITLE
updated the year to current year in docs and fundamental ratios link 

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -11,7 +11,7 @@ templates_path = ['_templates']
 source_suffix = '.rst'
 master_doc = 'index'
 project = 'ib_insync'
-copyright = '2022, Ewald de Wit'
+copyright = '2023, Ewald de Wit'
 author = 'Ewald de Wit'
 
 __version__ = ''

--- a/docs/html/_modules/ib_insync/client.html
+++ b/docs/html/_modules/ib_insync/client.html
@@ -1077,7 +1077,7 @@
   <hr/>
 
   <div role="contentinfo">
-    <p>&#169; Copyright 2022, Ewald de Wit.</p>
+    <p>&#169; Copyright 2023, Ewald de Wit.</p>
   </div>
 
   Built with <a href="https://www.sphinx-doc.org/">Sphinx</a> using a

--- a/docs/html/_modules/ib_insync/contract.html
+++ b/docs/html/_modules/ib_insync/contract.html
@@ -632,7 +632,7 @@
   <hr/>
 
   <div role="contentinfo">
-    <p>&#169; Copyright 2022, Ewald de Wit.</p>
+    <p>&#169; Copyright 2023, Ewald de Wit.</p>
   </div>
 
   Built with <a href="https://www.sphinx-doc.org/">Sphinx</a> using a

--- a/docs/html/_modules/ib_insync/flexreport.html
+++ b/docs/html/_modules/ib_insync/flexreport.html
@@ -208,7 +208,7 @@
   <hr/>
 
   <div role="contentinfo">
-    <p>&#169; Copyright 2022, Ewald de Wit.</p>
+    <p>&#169; Copyright 2023, Ewald de Wit.</p>
   </div>
 
   Built with <a href="https://www.sphinx-doc.org/">Sphinx</a> using a

--- a/docs/html/_modules/ib_insync/ib.html
+++ b/docs/html/_modules/ib_insync/ib.html
@@ -2285,7 +2285,7 @@
   <hr/>
 
   <div role="contentinfo">
-    <p>&#169; Copyright 2022, Ewald de Wit.</p>
+    <p>&#169; Copyright 2023, Ewald de Wit.</p>
   </div>
 
   Built with <a href="https://www.sphinx-doc.org/">Sphinx</a> using a

--- a/docs/html/_modules/ib_insync/ibcontroller.html
+++ b/docs/html/_modules/ib_insync/ibcontroller.html
@@ -439,7 +439,7 @@
   <hr/>
 
   <div role="contentinfo">
-    <p>&#169; Copyright 2022, Ewald de Wit.</p>
+    <p>&#169; Copyright 2023, Ewald de Wit.</p>
   </div>
 
   Built with <a href="https://www.sphinx-doc.org/">Sphinx</a> using a

--- a/docs/html/_modules/ib_insync/objects.html
+++ b/docs/html/_modules/ib_insync/objects.html
@@ -580,7 +580,7 @@
   <hr/>
 
   <div role="contentinfo">
-    <p>&#169; Copyright 2022, Ewald de Wit.</p>
+    <p>&#169; Copyright 2023, Ewald de Wit.</p>
   </div>
 
   Built with <a href="https://www.sphinx-doc.org/">Sphinx</a> using a

--- a/docs/html/_modules/ib_insync/objects.html
+++ b/docs/html/_modules/ib_insync/objects.html
@@ -567,7 +567,7 @@
 <div class="viewcode-block" id="FundamentalRatios"><a class="viewcode-back" href="../../api.html#ib_insync.objects.FundamentalRatios">[docs]</a><span class="k">class</span> <span class="nc">FundamentalRatios</span><span class="p">(</span><span class="n">DynamicObject</span><span class="p">):</span>
     <span class="sd">&quot;&quot;&quot;</span>
 <span class="sd">    See:</span>
-<span class="sd">    https://interactivebrokers.github.io/tws-api/fundamental_ratios_tags.html</span>
+<span class="sd">    https://web.archive.org/web/20200725010343/https://interactivebrokers.github.io/tws-api/fundamental_ratios_tags.html</span>
 <span class="sd">    &quot;&quot;&quot;</span>
 
     <span class="k">pass</span></div>

--- a/docs/html/_modules/ib_insync/order.html
+++ b/docs/html/_modules/ib_insync/order.html
@@ -493,7 +493,7 @@
   <hr/>
 
   <div role="contentinfo">
-    <p>&#169; Copyright 2022, Ewald de Wit.</p>
+    <p>&#169; Copyright 2023, Ewald de Wit.</p>
   </div>
 
   Built with <a href="https://www.sphinx-doc.org/">Sphinx</a> using a

--- a/docs/html/_modules/ib_insync/ticker.html
+++ b/docs/html/_modules/ib_insync/ticker.html
@@ -443,7 +443,7 @@
   <hr/>
 
   <div role="contentinfo">
-    <p>&#169; Copyright 2022, Ewald de Wit.</p>
+    <p>&#169; Copyright 2023, Ewald de Wit.</p>
   </div>
 
   Built with <a href="https://www.sphinx-doc.org/">Sphinx</a> using a

--- a/docs/html/_modules/ib_insync/util.html
+++ b/docs/html/_modules/ib_insync/util.html
@@ -631,7 +631,7 @@
   <hr/>
 
   <div role="contentinfo">
-    <p>&#169; Copyright 2022, Ewald de Wit.</p>
+    <p>&#169; Copyright 2023, Ewald de Wit.</p>
   </div>
 
   Built with <a href="https://www.sphinx-doc.org/">Sphinx</a> using a

--- a/docs/html/_modules/ib_insync/wrapper.html
+++ b/docs/html/_modules/ib_insync/wrapper.html
@@ -1270,7 +1270,7 @@
   <hr/>
 
   <div role="contentinfo">
-    <p>&#169; Copyright 2022, Ewald de Wit.</p>
+    <p>&#169; Copyright 2023, Ewald de Wit.</p>
   </div>
 
   Built with <a href="https://www.sphinx-doc.org/">Sphinx</a> using a

--- a/docs/html/_modules/ib_insync/wrapper.html
+++ b/docs/html/_modules/ib_insync/wrapper.html
@@ -874,7 +874,7 @@
             <span class="k">elif</span> <span class="n">tickType</span> <span class="o">==</span> <span class="mi">84</span><span class="p">:</span>
                 <span class="n">ticker</span><span class="o">.</span><span class="n">lastExchange</span> <span class="o">=</span> <span class="n">value</span>
             <span class="k">elif</span> <span class="n">tickType</span> <span class="o">==</span> <span class="mi">47</span><span class="p">:</span>
-                <span class="c1"># https://interactivebrokers.github.io/tws-api/fundamental_ratios_tags.html</span>
+                <span class="c1"># https://web.archive.org/web/20200725010343/https://interactivebrokers.github.io/tws-api/fundamental_ratios_tags.html</span>
                 <span class="n">d</span> <span class="o">=</span> <span class="nb">dict</span><span class="p">(</span><span class="n">t</span><span class="o">.</span><span class="n">split</span><span class="p">(</span><span class="s1">&#39;=&#39;</span><span class="p">)</span>                     <span class="c1"># type: ignore</span>
                          <span class="k">for</span> <span class="n">t</span> <span class="ow">in</span> <span class="n">value</span><span class="o">.</span><span class="n">split</span><span class="p">(</span><span class="s1">&#39;;&#39;</span><span class="p">)</span> <span class="k">if</span> <span class="n">t</span><span class="p">)</span>  <span class="c1"># type: ignore</span>
                 <span class="k">for</span> <span class="n">k</span><span class="p">,</span> <span class="n">v</span> <span class="ow">in</span> <span class="n">d</span><span class="o">.</span><span class="n">items</span><span class="p">():</span>

--- a/docs/html/_modules/index.html
+++ b/docs/html/_modules/index.html
@@ -90,7 +90,7 @@
   <hr/>
 
   <div role="contentinfo">
-    <p>&#169; Copyright 2022, Ewald de Wit.</p>
+    <p>&#169; Copyright 2023, Ewald de Wit.</p>
   </div>
 
   Built with <a href="https://www.sphinx-doc.org/">Sphinx</a> using a

--- a/docs/html/api.html
+++ b/docs/html/api.html
@@ -12275,7 +12275,7 @@ This is a non-recursive variant of <code class="docutils literal notranslate"><s
   <hr/>
 
   <div role="contentinfo">
-    <p>&#169; Copyright 2022, Ewald de Wit.</p>
+    <p>&#169; Copyright 2023, Ewald de Wit.</p>
   </div>
 
   Built with <a href="https://www.sphinx-doc.org/">Sphinx</a> using a

--- a/docs/html/api.html
+++ b/docs/html/api.html
@@ -11435,7 +11435,7 @@ This is a non-recursive variant of <code class="docutils literal notranslate"><s
 <dt class="sig sig-object py" id="ib_insync.objects.FundamentalRatios">
 <em class="property"><span class="pre">class</span><span class="w"> </span></em><span class="sig-prename descclassname"><span class="pre">ib_insync.objects.</span></span><span class="sig-name descname"><span class="pre">FundamentalRatios</span></span><span class="sig-paren">(</span><em class="sig-param"><span class="o"><span class="pre">**</span></span><span class="n"><span class="pre">kwargs</span></span></em><span class="sig-paren">)</span><a class="reference internal" href="_modules/ib_insync/objects.html#FundamentalRatios"><span class="viewcode-link"><span class="pre">[source]</span></span></a><a class="headerlink" href="#ib_insync.objects.FundamentalRatios" title="Permalink to this definition"></a></dt>
 <dd><p>See:
-<a class="reference external" href="https://interactivebrokers.github.io/tws-api/fundamental_ratios_tags.html">https://interactivebrokers.github.io/tws-api/fundamental_ratios_tags.html</a></p>
+<a class="reference external" href="https://web.archive.org/web/20200725010343/https://interactivebrokers.github.io/tws-api/fundamental_ratios_tags.html">https://web.archive.org/web/20200725010343/https://interactivebrokers.github.io/tws-api/fundamental_ratios_tags.html</a></p>
 </dd></dl>
 
 <dl class="py class">

--- a/docs/html/changelog.html
+++ b/docs/html/changelog.html
@@ -1103,7 +1103,7 @@ the request parameters.</p></li>
   <hr/>
 
   <div role="contentinfo">
-    <p>&#169; Copyright 2022, Ewald de Wit.</p>
+    <p>&#169; Copyright 2023, Ewald de Wit.</p>
   </div>
 
   Built with <a href="https://www.sphinx-doc.org/">Sphinx</a> using a

--- a/docs/html/code.html
+++ b/docs/html/code.html
@@ -99,7 +99,7 @@
   <hr/>
 
   <div role="contentinfo">
-    <p>&#169; Copyright 2022, Ewald de Wit.</p>
+    <p>&#169; Copyright 2023, Ewald de Wit.</p>
   </div>
 
   Built with <a href="https://www.sphinx-doc.org/">Sphinx</a> using a

--- a/docs/html/genindex.html
+++ b/docs/html/genindex.html
@@ -3300,7 +3300,7 @@
   <hr/>
 
   <div role="contentinfo">
-    <p>&#169; Copyright 2022, Ewald de Wit.</p>
+    <p>&#169; Copyright 2023, Ewald de Wit.</p>
   </div>
 
   Built with <a href="https://www.sphinx-doc.org/">Sphinx</a> using a

--- a/docs/html/index.html
+++ b/docs/html/index.html
@@ -243,7 +243,7 @@ IB-insync and anything related to it.</p>
   <hr/>
 
   <div role="contentinfo">
-    <p>&#169; Copyright 2022, Ewald de Wit.</p>
+    <p>&#169; Copyright 2023, Ewald de Wit.</p>
   </div>
 
   Built with <a href="https://www.sphinx-doc.org/">Sphinx</a> using a

--- a/docs/html/links.html
+++ b/docs/html/links.html
@@ -96,7 +96,7 @@
   <hr/>
 
   <div role="contentinfo">
-    <p>&#169; Copyright 2022, Ewald de Wit.</p>
+    <p>&#169; Copyright 2023, Ewald de Wit.</p>
   </div>
 
   Built with <a href="https://www.sphinx-doc.org/">Sphinx</a> using a

--- a/docs/html/notebooks.html
+++ b/docs/html/notebooks.html
@@ -114,7 +114,7 @@ Here are some recipe notebooks:</p>
   <hr/>
 
   <div role="contentinfo">
-    <p>&#169; Copyright 2022, Ewald de Wit.</p>
+    <p>&#169; Copyright 2023, Ewald de Wit.</p>
   </div>
 
   Built with <a href="https://www.sphinx-doc.org/">Sphinx</a> using a

--- a/docs/html/py-modindex.html
+++ b/docs/html/py-modindex.html
@@ -140,7 +140,7 @@
   <hr/>
 
   <div role="contentinfo">
-    <p>&#169; Copyright 2022, Ewald de Wit.</p>
+    <p>&#169; Copyright 2023, Ewald de Wit.</p>
   </div>
 
   Built with <a href="https://www.sphinx-doc.org/">Sphinx</a> using a

--- a/docs/html/readme.html
+++ b/docs/html/readme.html
@@ -183,7 +183,7 @@ IB-insync and anything related to it.</p>
   <hr/>
 
   <div role="contentinfo">
-    <p>&#169; Copyright 2022, Ewald de Wit.</p>
+    <p>&#169; Copyright 2023, Ewald de Wit.</p>
   </div>
 
   Built with <a href="https://www.sphinx-doc.org/">Sphinx</a> using a

--- a/docs/html/recipes.html
+++ b/docs/html/recipes.html
@@ -357,7 +357,7 @@ run for short whiles and keep up to date:</p>
   <hr/>
 
   <div role="contentinfo">
-    <p>&#169; Copyright 2022, Ewald de Wit.</p>
+    <p>&#169; Copyright 2023, Ewald de Wit.</p>
   </div>
 
   Built with <a href="https://www.sphinx-doc.org/">Sphinx</a> using a

--- a/docs/html/search.html
+++ b/docs/html/search.html
@@ -93,7 +93,7 @@
   <hr/>
 
   <div role="contentinfo">
-    <p>&#169; Copyright 2022, Ewald de Wit.</p>
+    <p>&#169; Copyright 2023, Ewald de Wit.</p>
   </div>
 
   Built with <a href="https://www.sphinx-doc.org/">Sphinx</a> using a

--- a/ib_insync/objects.py
+++ b/ib_insync/objects.py
@@ -493,7 +493,7 @@ class DynamicObject:
 class FundamentalRatios(DynamicObject):
     """
     See:
-    https://interactivebrokers.github.io/tws-api/fundamental_ratios_tags.html
+    https://web.archive.org/web/20200725010343/https://interactivebrokers.github.io/tws-api/fundamental_ratios_tags.html
     """
 
     pass

--- a/ib_insync/wrapper.py
+++ b/ib_insync/wrapper.py
@@ -800,7 +800,7 @@ class Wrapper:
             elif tickType == 84:
                 ticker.lastExchange = value
             elif tickType == 47:
-                # https://interactivebrokers.github.io/tws-api/fundamental_ratios_tags.html
+                # https://web.archive.org/web/20200725010343/https://interactivebrokers.github.io/tws-api/fundamental_ratios_tags.html
                 d = dict(t.split('=')                     # type: ignore
                          for t in value.split(';') if t)  # type: ignore
                 for k, v in d.items():


### PR DESCRIPTION
Small fix: updated the year 2022 to the current year 2023 in all the docs. 
Updated the broken link for Fundamental Ratios(deprecated) with archive(.)org snapshot link #587