### PR TITLE
Check contract details has time zone ID

### DIFF
--- a/ib_insync/contract.py
+++ b/ib_insync/contract.py
@@ -525,7 +525,7 @@ class ContractDetails:
 
     def _parseSessions(self, s: str) -> List[TradingSession]:
         sessions = []
-        if self.timeZoneId:
+        if s:
             tz = util.ZoneInfo(self.timeZoneId)
             for sess in s.split(';'):
                 if not sess or 'CLOSED' in sess:

--- a/ib_insync/contract.py
+++ b/ib_insync/contract.py
@@ -524,14 +524,15 @@ class ContractDetails:
         return self._parseSessions(self.liquidHours)
 
     def _parseSessions(self, s: str) -> List[TradingSession]:
-        tz = util.ZoneInfo(self.timeZoneId)
         sessions = []
-        for sess in s.split(';'):
-            if not sess or 'CLOSED' in sess:
-                continue
-            sessions.append(TradingSession(*[
-                dt.datetime.strptime(t, '%Y%m%d:%H%M').replace(tzinfo=tz)
-                for t in sess.split('-')]))
+        if self.timeZoneId:
+            tz = util.ZoneInfo(self.timeZoneId)
+            for sess in s.split(';'):
+                if not sess or 'CLOSED' in sess:
+                    continue
+                sessions.append(TradingSession(*[
+                    dt.datetime.strptime(t, '%Y%m%d:%H%M').replace(tzinfo=tz)
+                    for t in sess.split('-')]))
         return sessions
 
 


### PR DESCRIPTION
Contracts about to expire may not have `tradingHours`, `liquidHours`, and `timeZoneId` set. This was causing an error when `_parseSessions` is called:
```python
Exception has occurred: ValueError
ZoneInfo keys must be normalized relative paths, got: 
```
A simple way to avoid the error would be to check if the argument string is empty.

