### PR TITLE
Remove incorrect code from contract details decoder

### DIFF
--- a/ib_insync/decoder.py
+++ b/ib_insync/decoder.py
@@ -329,8 +329,6 @@ class Decoder:
             c.lastTradeDateOrContractMonth = times[0]
         if len(times) > 1:
             cd.lastTradeTime = times[1]
-        if len(times) > 2:
-            cd.timeZoneId = times[2]
 
         cd.longName = cd.longName.encode().decode('unicode-escape')
         self.parse(cd)


### PR DESCRIPTION
Problem - The current contract details decoder contains a bit of code that should only be used in the bond contract details decoder.

Effect - The function first correctly assigns the timeZoneId, but then later in the function body overwrites it with the timezone TWS is set to use.

Solution - Delete the extra code.

For reference, here is the logic from the official API from Interactive Brokers:
```python
def readLastTradeDate(self, fields, contract: ContractDetails, isBond: bool):
        lastTradeDateOrContractMonth = decode(str, fields)
        if lastTradeDateOrContractMonth is not None:
            if '-' in lastTradeDateOrContractMonth: 
                splitted = lastTradeDateOrContractMonth.split('-')
            else:
                splitted = lastTradeDateOrContractMonth.split()
                
            if len(splitted) > 0:
                if isBond:
                    contract.maturity = splitted[0]
                else:
                    contract.contract.lastTradeDateOrContractMonth = splitted[0]

            if len(splitted) > 1:
                contract.lastTradeTime = splitted[1]

            if isBond and len(splitted) > 2:
                contract.timeZoneId = splitted[2]
```