### PR TITLE
Include class name while serializing NamedTuple

### DIFF
--- a/ib_insync/util.py
+++ b/ib_insync/util.py
@@ -146,7 +146,7 @@ def tree(obj):
     elif isinstance(obj, dict):
         return {k: tree(v) for k, v in obj.items()}
     elif isnamedtupleinstance(obj):
-        return {f: tree(getattr(obj, f)) for f in obj._fields}
+        return {obj.__class__.__name__: {f: tree(getattr(obj, f)) for f in obj._fields}}
     elif isinstance(obj, (list, tuple, set)):
         return [tree(i) for i in obj]
     elif is_dataclass(obj):

--- a/ib_insync/util.py
+++ b/ib_insync/util.py
@@ -146,7 +146,8 @@ def tree(obj):
     elif isinstance(obj, dict):
         return {k: tree(v) for k, v in obj.items()}
     elif isnamedtupleinstance(obj):
-        return {obj.__class__.__name__: {f: tree(getattr(obj, f)) for f in obj._fields}}
+        return {obj.__class__.__name__: {
+            f: tree(getattr(obj, f)) for f in obj._fields}}
     elif isinstance(obj, (list, tuple, set)):
         return [tree(i) for i in obj]
     elif is_dataclass(obj):


### PR DESCRIPTION
Before:
```
[...]
 'fills': [{'contract': {'Future': {'secType': 'FUT',
      'conId': 603558783,
      'symbol': 'YM',
      'lastTradeDateOrContractMonth': '20231215',
      'right': '?',
      'multiplier': '5',
[...]
```
After:
```
[...]
  'fills': [{'Fill': {'contract': {'Future': {'secType': 'FUT',
       'conId': 603558783,
       'symbol': 'YM',
       'lastTradeDateOrContractMonth': '20231215',
       'right': '?',
       'multiplier': '5',
       'exchange': 'CBOT',
       'currency': 'USD',
       'localSymbol': 'YM   DEC 23',
       'tradingClass': 'YM'}},
     'execution': {'Execution': {'execId': '0000e1a7.656fc43c.01.01',
       'time': '2023-12-06T09:48:35+00:00',
    [...]
```
It's much easier to de-serialize if class name is included.
